### PR TITLE
Delete tmpfile so the /tmp directory doesn't fill up

### DIFF
--- a/lib/eeepub/maker.rb
+++ b/lib/eeepub/maker.rb
@@ -133,6 +133,9 @@ module EeePub
         :dir => dir,
         :container => @opf_file
       )
+
+      FileUtils.remove_entry_secure dir
+
     end
   end
 end


### PR DESCRIPTION
Here's a quick patch that might fix this. Note that easy.rb doesn't have this problem, because it uses the block passed to mktmpdir syntax rather than the declaration syntax. More about this here: http://ruby-doc.org/stdlib/libdoc/tmpdir/rdoc/classes/Dir.html
