### PR TITLE
clean up the tmpdir after creating or streaming the epub

### DIFF
--- a/lib/eeepub/ocf.rb
+++ b/lib/eeepub/ocf.rb
@@ -102,6 +102,7 @@ module EeePub
           end
         end
       end
+      FileUtils.remove_entry_secure dir
     end
     
     # Stream OCF
@@ -118,6 +119,7 @@ module EeePub
             end
           end
         end
+        FileUtils.remove_entry_secure dir
 
         return buffer
       end


### PR DESCRIPTION
This is tested and working as a patch in my application
