### PR TITLE
fix actual zipping of epub

### DIFF
--- a/lib/eeepub/ocf.rb
+++ b/lib/eeepub/ocf.rb
@@ -97,7 +97,7 @@ module EeePub
             if File.directory?(path)
               zip.add_dir(path)
             else
-              zip.add_file(path)
+              zip.add_file(path, path)
             end
           end
         end
@@ -112,9 +112,9 @@ module EeePub
         buffer = Zip::Archive.open_buffer(Zip::CREATE) do |zip|
           Dir.glob('**/*').each do |path|
             if File.directory?(path)
-              zip.add_buffer(path, path)
+              zip.add_dir(path)
             else
-              zip.add_buffer(path, File.read(path))
+              zip.add_file(path, path)
             end
           end
         end


### PR DESCRIPTION
The zip archiving was not being called correctly, causing the actual epub file to have a flattened manifest like this:

```
$  find .
.
./container.xml
./content.opf
./doc.html
./images
./image.jpg
./META-INF
./mimetype
./toc.ncx
```

as opposed to what it should be, like this:

```
$  find .
.
./content.opf
./doc.html
./images/image.jpg
./META-INF/container.xml
./mimetype
./toc.ncx
```

This patch fixes the lib so that it is using the Zip::Archive API properly.
