### PR TITLE
Fixes epubcheck errors

### DIFF
--- a/examples/simple_epub.rb
+++ b/examples/simple_epub.rb
@@ -9,8 +9,6 @@ epub = EeePub.make do
   creator     'jugyo'
   publisher   'jugyo.org'
   date        '2010-05-06'
-  identifier  'http://example.com/book/foo', :scheme => 'URL'
-  uid         'http://example.com/book/foo'
 
   files [File.join(dir, 'foo.html'), File.join(dir, 'bar.html')]
   nav [


### PR DESCRIPTION
In order to be a completely valid EPub the mimetype file must be first
in the archive and be stored uncompressed with no extra file data.
- Switched from zipruby to rubyzip. Nothing I tried with zipruby allowed
  me to write the mimetype data uncompressed in a clean way.
- Had to use a Tempfile for the buffered output since rubyzip appears to
  only work with files.
