### PR TITLE
Generate proper XML IDs

### DIFF
--- a/lib/eeepub/opf.rb
+++ b/lib/eeepub/opf.rb
@@ -137,14 +137,12 @@ module EeePub
 
     def create_unique_item_id(filename, id_cache)
       basename = File.basename(filename)
-      unless id_cache[basename]
-        id_cache[basename] = 0
-        name = basename
-      else
-        name = "#{basename}-#{id_cache[basename]}"
-      end
+      id_cache[basename] ||= 0
+      name = "#{basename}-#{id_cache[basename]}"
+
       id_cache[basename] += 1
-      name
+
+      return name
     end
   end
 end

--- a/lib/eeepub/opf.rb
+++ b/lib/eeepub/opf.rb
@@ -138,7 +138,7 @@ module EeePub
     def create_unique_item_id(filename, id_cache)
       basename = File.basename(filename)
       id_cache[basename] ||= 0
-      name = "#{basename}-#{id_cache[basename]}"
+      name = "id-#{basename}-#{id_cache[basename]}".gsub(/[^a-zA-Z0-9\-.]/, '-')
 
       id_cache[basename] += 1
 


### PR DESCRIPTION
The current code relies on the name of the file to generate an ID for that file. Filenames may contain characters that are not allowed in XML IDs.

These commits make sure that the generated IDs are proper XML IDs.
