### PR TITLE
Use only the value of the UID in the NCX

### DIFF
--- a/lib/eeepub/ncx.rb
+++ b/lib/eeepub/ncx.rb
@@ -27,7 +27,7 @@ module EeePub
     def build_head(builder)
       builder.head do
         {
-          :uid => uid,
+          :uid => uid[:value],
           :depth => depth,
           :totalPageCount => total_page_count,
           :maxPageNumber => max_page_number


### PR DESCRIPTION
The `@uid` variable contains an Hash with `:value`, `:scheme` and `:id` keys.
We want only the value of the identifier, not the other attributes.
