### PR TITLE
explicitly sets the version of rubyzip

### DIFF
--- a/eeepub.gemspec
+++ b/eeepub.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "builder"
-  s.add_dependency "rubyzip"
+  s.add_dependency "rubyzip", "~> 0.9.9"
   s.add_development_dependency "rspec"
   s.add_development_dependency "nokogiri"
   s.add_development_dependency "rr"


### PR DESCRIPTION
Rubyzip v 1.0.0 has breaking changes - in that it has changed several file and class names - thus breaking the functionality of all gems that require it "the old way". 

By specifying the version explicitly this is circumvented (without the need to change the gems source code).
